### PR TITLE
Change softdepend to depend (fixes plugin)

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,6 +4,6 @@ version: "${project.version}"
 description: "${project.description}"
 api-version: "1.16"
 authors: [ BillyGalbreath ]
-softdepend:
+depend:
   - GriefPrevention
   - Pl3xMap


### PR DESCRIPTION
This should make the plugin load after GriefPrevention.
If it's set to `softdepend`, the plugin won't load as it will load before GriefPrevention and not detect it.
Making it `depend` forces it to load **after** GriefPrevention (and Pl3xMap) which should remove any issues.

This fixes https://github.com/pl3xgaming/Pl3xMap-GriefPrevention/issues/4

Direct download (unzip it): [Pl3xMap-GriefPrevention Fix.zip](https://github.com/pl3xgaming/Pl3xMap-GriefPrevention/files/7289294/Pl3xMap-GriefPrevention.Fix.zip)